### PR TITLE
fix: allow partial updates for user profile including profile picture

### DIFF
--- a/app/user/serializers.py
+++ b/app/user/serializers.py
@@ -23,6 +23,15 @@ class UserSerializer(serializers.ModelSerializer):
             'profile_picture': {'required': False},
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Check if it's update, make fields optional
+        if self.instance:
+            self.fields['email'].required = False
+            self.fields['first_name'].required = False
+            self.fields['last_name'].required = False
+            self.fields['password'].required = False
+
     def create(self, validated_data):
         """Create a new user with encrypted password and return it"""
         return get_user_model().objects.create_user(**validated_data)


### PR DESCRIPTION
- Fixed issue where PATCH to /api/user/me/ required all fields
- Made email, first_name, last_name, and password optional during updates
- Users can now update profile_picture without providing other fields